### PR TITLE
Fix the build error of pmoncfg

### DIFF
--- a/build_ls1c_openloongson.sh
+++ b/build_ls1c_openloongson.sh
@@ -14,7 +14,9 @@ if ! [ "`which pmoncfg`" ] ; then
 apt-get update
 apt-get -y install zlib1g  make bison flex ccache libc6-dev xutils-dev
 cd tools/pmoncfg
+make clean
 make
+cp pmoncfg /opt/mips-loongson-gcc7.3-linux-gnu/2019.06-29/bin
 cd ../..
 fi
 

--- a/tools/pmoncfg/Makefile
+++ b/tools/pmoncfg/Makefile
@@ -10,7 +10,7 @@ SRCS=	files.c gram.y hash.c main.c mkheaders.c mkioconf.c mkmakefile.c \
 
 OBJS=	files.o hash.o main.o mkheaders.o mkioconf.o mkmakefile.o pack.o sem.o util.o gram.o scan.o 
 
-CFLAGS+=-I${.CURDIR} -I. -DYY_SKIP_YYWRAP
+CFLAGS+= -fcommon -I${.CURDIR} -I. -DYY_SKIP_YYWRAP
 
 LEX=flex
 
@@ -22,7 +22,7 @@ MAN=	pmoncfg.8
 	${BISON} -d -o $@ $< 
 
 ${PROG}: ${OBJS}
-	${CC} -o $@ ${OBJS} ${LIBS}
+	${CC} ${CFLAGS} -o $@ ${OBJS} ${LIBS}
 
 install:
 	cp ${PROG} ${DESTDIR}/bin


### PR DESCRIPTION
Fix the following build error by adding -fcommon to CFLAGS.

cc -o pmoncfg files.o hash.o main.o mkheaders.o mkioconf.o mkmakefile.o pack.o sem.o util.o gram.o scan.o /usr/bin/ld: hash.o:(.bss+0x0): multiple definition of `conffile'; files.o:(.bss+0x0): first defined here ...